### PR TITLE
fix for acf search filter

### DIFF
--- a/app/controllers/class-kili-search-filter.php
+++ b/app/controllers/class-kili-search-filter.php
@@ -58,7 +58,7 @@ class Kili_Search_Filter {
 	public function cf_search_join( $join ) {
 		global $wpdb;
 		if ( is_search() ) {
-			$join .= ' LEFT JOIN ' . $wpdb->postmeta . ' ON ' . $wpdb->posts . '.ID = ' . $wpdb->postmeta . '.post_id ';
+			$join .= ' LEFT JOIN ' . $wpdb->postmeta . ' cfpm ON ' . $wpdb->posts . '.ID = cfpm.post_id ';
 		}
 		return $join;
 	}
@@ -75,7 +75,7 @@ class Kili_Search_Filter {
 		if ( is_search() ) {
 			$where = preg_replace(
 				'/\(\s*' . $wpdb->posts . ".post_title\s+LIKE\s*(\'[^\']+\')\s*\)/",
-				'(' . $wpdb->posts . '.post_title LIKE $1) OR (' . $wpdb->postmeta . '.meta_value LIKE $1)', $where
+				'(' . $wpdb->posts . '.post_title LIKE $1) OR (cfpm.meta_value LIKE $1)', $where
 			);
 		}
 		return $where;

--- a/app/controllers/class-kili-search-filter.php
+++ b/app/controllers/class-kili-search-filter.php
@@ -13,12 +13,12 @@ class Kili_Search_Filter {
 	 * Class constructor
 	 */
 	public function __construct() {
-		add_filter( 'pre_get_posts', array( $this, 'search_filter' ) );
+		add_filter( 'pre_get_posts', array( $this, 'kili_filter_search' ) );
 		if ( current_theme_supports( 'kili-enable-acf-search' ) ) {
-			$this->add_cf_search_filters();
+			$this->kili_add_cf_search_filters();
 		}
 		if ( current_theme_supports( 'kili-nice-search' ) ) {
-			$this->add_nice_search_filters();
+			$this->kili_add_nice_search_filters();
 		}
 	}
 
@@ -28,7 +28,7 @@ class Kili_Search_Filter {
 	 * @param object $query The search query object.
 	 * @return object Search query object with the post type filter
 	 */
-	public function search_filter( $query ) {
+	public function kili_filter_search( $query ) {
 		if ( $query->is_search && ! is_admin() ) {
 			$post_type = isset( $_REQUEST['post_type'] ) ? sanitize_key( wp_unslash( $_REQUEST['post_type'] ) ) : 'post';
 			$query->set( 'post_type', array( $post_type ) );
@@ -42,10 +42,10 @@ class Kili_Search_Filter {
 	 * @author adambalee (http://adambalee.com)
 	 * @return void
 	 */
-	private function add_cf_search_filters() {
-		add_filter( 'posts_join', array( $this, 'cf_search_join' ) );
-		add_filter( 'posts_where', array( $this, 'cf_search_where' ) );
-		add_filter( 'posts_distinct', array( $this, 'cf_search_distinct' ) );
+	private function kili_add_cf_search_filters() {
+		add_filter( 'posts_join', array( $this, 'kili_cf_search_join' ) );
+		add_filter( 'posts_where', array( $this, 'kili_cf_search_where' ) );
+		add_filter( 'posts_distinct', array( $this, 'kili_cf_search_distinct' ) );
 	}
 
 	/**
@@ -55,7 +55,7 @@ class Kili_Search_Filter {
 	 * @param object $join The search query string.
 	 * @return string Modified search query string
 	 */
-	public function cf_search_join( $join ) {
+	public function kili_cf_search_join( $join ) {
 		global $wpdb;
 		if ( is_search() ) {
 			$join .= ' LEFT JOIN ' . $wpdb->postmeta . ' cfpm ON ' . $wpdb->posts . '.ID = cfpm.post_id ';
@@ -70,7 +70,7 @@ class Kili_Search_Filter {
 	 * @param object $where The search query string.
 	 * @return string Modified search query string
 	 */
-	public function cf_search_where( $where ) {
+	public function kili_cf_search_where( $where ) {
 		global $wpdb;
 		if ( is_search() ) {
 			$where = preg_replace(
@@ -88,7 +88,7 @@ class Kili_Search_Filter {
 	 * @param object $where The search query string.
 	 * @return string Modified search query string
 	 */
-	public function cf_search_distinct( $where ) {
+	public function kili_cf_search_distinct( $where ) {
 		if ( is_search() ) {
 			return 'DISTINCT';
 		}
@@ -100,10 +100,10 @@ class Kili_Search_Filter {
 	 *
 	 * @return void
 	 */
-	public function add_nice_search_filters() {
-		add_action( 'template_redirect', array( $this, 'ksource_search_redirect' ) );
-		add_filter( 'wpseo_json_ld_search_url', array( $this, 'ksource_search_rewrite' ) );
-		add_action( 'init', array( $this, 'search_base_slug' ) );
+	public function kili_add_nice_search_filters() {
+		add_action( 'template_redirect', array( $this, 'kili_search_redirect' ) );
+		add_filter( 'wpseo_json_ld_search_url', array( $this, 'kili_search_rewrite' ) );
+		add_action( 'init', array( $this, 'kili_search_base_slug' ) );
 	}
 
 	/**
@@ -111,7 +111,7 @@ class Kili_Search_Filter {
 	 *
 	 * @return void
 	 */
-	public function ksource_search_redirect() {
+	public function kili_search_redirect() {
 		global $wp_rewrite;
 		if ( ! isset( $wp_rewrite ) || ! is_object( $wp_rewrite ) || ! $wp_rewrite->get_search_permastruct() ) {
 			return;
@@ -134,7 +134,7 @@ class Kili_Search_Filter {
 	 * @param string $url The URL string.
 	 * @return string The new URL string
 	 */
-	public function ksource_search_rewrite( $url ) {
+	public function kili_search_rewrite( $url ) {
 		return str_replace( '/?s=', '/' . __( 'search' ) . '/', $url );
 	}
 
@@ -143,7 +143,7 @@ class Kili_Search_Filter {
 	 *
 	 * @return void
 	 */
-	public function search_base_slug() {
+	public function kili_search_base_slug() {
 		$search_slug = __( 'search' ); // change slug name.
 		$GLOBALS['wp_rewrite']->search_base = $search_slug;
 		$GLOBALS['wp_rewrite']->flush_rules();


### PR DESCRIPTION
When searching a custom post type, this error pops:
`Error en la base de datos de WordPress: [Not unique table/alias: 'wp_postmeta']
SELECT  DISTINCT wp_posts.* FROM wp_posts  INNER JOIN wp_postmeta ON ( wp_posts.ID = wp_postmeta.post_id ) LEFT JOIN wp_postmeta ON wp_posts.ID = wp_postmeta.post_id  WHERE 1=1  AND ( 
  wp_postmeta.meta_key = 'kili_block_builder'
) AND wp_posts.post_type IN ('post', 'page', 'attachment', 'revision', 'nav_menu_item', 'custom_css', 'customize_changeset', 'acf-field-group', 'acf-field', 'product') AND ((wp_posts.post_status = 'publish')) GROUP BY wp_posts.ID ORDER BY wp_posts.menu_order, wp_posts.post_date DESC `
This, at least, fixes this error